### PR TITLE
修复 404 终端交互细节

### DIFF
--- a/docs/.vitepress/theme/NotFound.vue
+++ b/docs/.vitepress/theme/NotFound.vue
@@ -571,7 +571,7 @@ const createWelcomeLines = () => welcomeTexts.map((text) => mcLine(text, 'menu')
 const createToolDeltaConsoleHelpLines = (): ScriptLine[] => [
   tdLogLine('info', '§a以下是可选的菜单指令项: '),
   tdLogLine('info', ' §e? 或 help 或 帮助 或 ？  §f->  查询可用菜单指令'),
-  tdLogLine('info', ' §eexit  §f->  退出并关闭ToolDelta'),
+  tdLogLine('info', ' §eexit  §f->  退出并返回启动菜单'),
   tdLogLine('info', ' §e插件市场  §f->  进入插件市场'),
 ]
 
@@ -1228,7 +1228,12 @@ const submitCommand = async () => {
     return
   }
 
-  if (normalized === 'fastbuilder') {
+  if (
+    normalized === 'fastbuilder' &&
+    !isToolDeltaMenuActive.value &&
+    !isToolDeltaRunning.value &&
+    !isPluginMarketActive.value
+  ) {
     terminalLines.value = []
     isFastBuilderStarted.value = true
     isToolDeltaMenuActive.value = false

--- a/docs/.vitepress/theme/PluginMarket.vue
+++ b/docs/.vitepress/theme/PluginMarket.vue
@@ -196,6 +196,7 @@ const currentItem = ref(null)
 const modalParentItem = ref(null)
 const copiedStates = reactive({})  // Use reactive for object property reactivity
 let modalResetTimer = null
+let queryTargetOpened = false
 
 const PRIMARY_MARKET_BASE_URL = 'https://pm.tooldelta.top'
 const GITHUB_RAW_MARKET_BASE_URL = 'https://raw.githubusercontent.com/ToolDelta-Basic/PluginMarket/refs/heads/main'
@@ -525,6 +526,7 @@ const showFullDescription = (item) => {
 
 const openQueryTargetModal = () => {
   if (typeof window === 'undefined') return false
+  if (queryTargetOpened) return false
   const params = new URLSearchParams(window.location.search)
   const pluginId = params.get('plugin')
   const packageName = params.get('package')
@@ -537,6 +539,7 @@ const openQueryTargetModal = () => {
   })
 
   if (!target) return false
+  queryTargetOpened = true
   showFullDescription(target)
   return true
 }


### PR DESCRIPTION
## 概述
- 修复插件市场页面通过 query 自动打开弹窗后，列表异步更新导致弹窗重复弹出的问题。
- 修正 404 终端中 ToolDelta help 的 exit 文案，使其符合当前模拟行为。
- 限制 fastbuilder 彩蛋仅在初始 shell 状态可用，避免在 ToolDelta 菜单中误触发。

## 验证
- 已通过 NotFound.vue 与 PluginMarket.vue 的 SFC parse/template 检查。